### PR TITLE
Filter classification 49 in potree

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -76,7 +76,7 @@ var rawRoot = 's3-us-west-2.amazonaws.com/usgs-lidar-public/';
 var root = 'https://' + rawRoot;
 var agRoot = 'https://d1xx504zn7lvnb.cloudfront.net/';
 var cfRoot = 'https://d2ywgo0ycqxchv.cloudfront.net/';
-var postfix = '&m=5&cf=%5B7%5D';
+var postfix = '&m=5&cf=%5B7,49%5D';
 
 var commify = (n) => {
     var commifyInt = (n) => n.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');

--- a/js/script.js
+++ b/js/script.js
@@ -198,10 +198,8 @@ var set = (k, v) => {
         case 'classificationFilter': case 'cf':
             for (var i = 0; i < v.length; ++i) {
                 var c = document.getElementById('chkClassification_' + v[i]);
-                if (c) {
-                    c.checked = false;
-                    viewer.setClassificationVisibility(v[i], false);
-                }
+                if (c) c.checked = false;
+                viewer.setClassificationVisibility(v[i], false);
             }
             break;
         case 'language': case 'l': case 'lang':


### PR DESCRIPTION
This is "high noise".  Particularly noticeable on [OR_Malheur_USFS_2010](https://usgs.entwine.io/data/view.html?r=%22https://s3-us-west-2.amazonaws.com/usgs-lidar-public/OR_Malheur_USFS_2010%22&m=3&era=%5B921,2789%5D&p=%5B-13194732.114575366,5517109.114575365,71863.35905090191%5D&t=%5B-13244235.5,5566612.5,1855.0000000000146%5D).

Because the UI doesn't list this classification, with this PR there is no way to toggle classification 49 back *on*.