### PR TITLE
Update generated Cesium links to point at updated EPT Tools deployment

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -88,8 +88,11 @@ var commify = (n) => {
 var potreeLinkify = (name) => '/data/view.html?r=' + root + name + postfix;
 
 var cesiumLinkify = (name) => {
-    const truncate = Boolean(name.includes('LPC'))
-    return `http://cesium.entwine.io/?url=http://usgs-3dtiles.entwine.io/${name}/ept-tileset/tileset.json&dimensions=Intensity&truncate=${truncate ? 1 : 0}&z-offset=0`
+    // Assume that LPC data has 16-bit intensity values, and non-LPC data does
+    // not.  For this most part this should be accurate but probably not with
+    // 100% accuracy.
+    const truncateIntensity = Boolean(name.includes('LPC'))
+    return `http://cesium.entwine.io/?url=http://usgs-3dtiles.entwine.io/${name}/ept-tileset/tileset.json&dimensions=Intensity&truncate-intensity=${truncateIntensity ? 1 : 0}&z-offset=0`
 }
 
 var plasioLinkify = (name) => 'http://dev.speck.ly/?s=0&r=ept://' +

--- a/js/app.js
+++ b/js/app.js
@@ -87,7 +87,10 @@ var commify = (n) => {
 
 var potreeLinkify = (name) => '/data/view.html?r=' + root + name + postfix;
 
-var cesiumLinkify = (name) => `http://cesium.entwine.io/?url=http://usgs-3dtiles.entwine.io/${name}/ept-tileset/tileset.json`
+var cesiumLinkify = (name) => {
+    const truncate = Boolean(name.includes('LPC'))
+    return `http://cesium.entwine.io/?url=http://usgs-3dtiles.entwine.io/${name}/ept-tileset/tileset.json&dimensions=Intensity&truncate=${truncate ? 1 : 0}&z-offset=0`
+}
 
 var plasioLinkify = (name) => 'http://dev.speck.ly/?s=0&r=ept://' +
     rawRoot + name + '&c0s=remote%3A%2F%2Fimagery%3Furl%3Dhttp%253A%252F%252Fserver.arcgisonline.com%252FArcGIS%252Frest%252Fservices%252FWorld_Imagery%252FMapServer%252Ftile%252F%257B%257Bz%257D%257D%252F%257B%257By%257D%257D%252F%257B%257Bx%257D%257D.jpg';
@@ -310,6 +313,8 @@ var Resources = React.createClass({
                     '<strong>' + name + '</strong>' +
                     '<br>' +
                     '(<a href="' + potreeLinkify(name) + '">Potree</a>)' +
+                    '&nbsp;' +
+                    '(<a href="' + cesiumLinkify(name) + '">Cesium</a>)' +
                 '</div>', { });
 
                 polygons[name] = { visible: true, polygon: layer}


### PR DESCRIPTION
EPT Tools now supports some new [options](https://github.com/connormanning/ept-tools/blob/master/doc/tiling-options.md) - update the Cesium links to use these.  In particular:

- Always request the `Intensity` dimension and color by this attribute by default (since most of this data does not have RGB).  Furthermore, assume that data with `LPC` in the name has 16-bit intensity, otherwise 8-bit intensity.  This should be mostly accurate and can be overridden manually in the cases where this assumption is wrong.
- Some data may appear partially underneath the terrain model.  We'll add a `z-offset` of `0` to the Cesium links here so it's clear that the height may be changed dynamically if needed.  EDIT: Updated default z-offset to 25 [here](dae809911fb1dd45c377d7af420f390d306aadea) since it is quite common to see this interference with 0 offset.