### PR TITLE
make the text filter case insensitive

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -153,7 +153,8 @@ var Resources = React.createClass({
             ? (a, b) => a < b
             : (a, b) => a > b;
 
-        var re = new RegExp(this.state.text, 'i');
+        const flags = this.state.text.match(/[A-Z]/) ? '' : 'i'
+        var re = new RegExp(this.state.text, flags);
         var resources = this.props.resources.filter((r) => r.name.match(re))
         .sort((a, b) => {
             if (this.state.sortCol == Column.Name) {

--- a/js/app.js
+++ b/js/app.js
@@ -153,7 +153,7 @@ var Resources = React.createClass({
             ? (a, b) => a < b
             : (a, b) => a > b;
 
-        var re = new RegExp(this.state.text);
+        var re = new RegExp(this.state.text, 'i');
         var resources = this.props.resources.filter((r) => r.name.match(re))
         .sort((a, b) => {
             if (this.state.sortCol == Column.Name) {


### PR DESCRIPTION
The existing text filter requires the user text to match the case of the pointcloud names, so a search for 'ny' only finds a couple pointclouds, neither of which are in New York state (since they just happen to include those letters within a name):
![image](https://user-images.githubusercontent.com/3355358/122995704-efa3f200-d377-11eb-896f-ff3c04af0621.png)

This PR makes the matching case insensitive, so that more matches are found:
![image](https://user-images.githubusercontent.com/3355358/122995904-372a7e00-d378-11eb-853c-401075e47980.png)

The behavior hopefully better matches users' expectations.