### PR TITLE
Fix STAC schema creation from EPT sources

### DIFF
--- a/action/setup.py
+++ b/action/setup.py
@@ -34,7 +34,8 @@ setup(
     #
     # For an analysis of "install_requires" vs pip's requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['gdal','boto3', 'Shapely', 'Fiona','pyproj'],  # Optional
+    # need pdal installed for command.py to run correctly
+    install_requires=['gdal','boto3', 'Shapely', 'Fiona','pyproj', 'pystac'],  # Optional
 
 
     # To provide executable scripts, use entry points in preference to the
@@ -47,7 +48,7 @@ setup(
     entry_points={  # Optional
         'console_scripts': [
             'usgs-boundary=usgs_boundary.command:main',
-            'usgs-stac=usgs_boundary.stac:main',
+            # 'usgs-stac=usgs_boundary.stac:main',
         ],
     },
 

--- a/action/usgs_boundary/layer.py
+++ b/action/usgs_boundary/layer.py
@@ -73,6 +73,9 @@ class Layer(object):
         s = tile.ept['schema']
         p = []
         for d in s:
+            # change 'float' to 'floating' to fit pointcloud stac schema
+            if d['type'] == 'float':
+                d['type'] = 'floating'
             p.append(Schema(d))
 
 


### PR DESCRIPTION
EPT sources for github action use `floating` instead of `float`, as the [pointcloud STAC extension](https://stac-extensions.github.io/pointcloud/v1.0.0/schema.json) requires. This PR adds a check when creating the schema that changes values from `floating` to `float`.