### PR TITLE
Map layer update

### DIFF
--- a/js/about.js
+++ b/js/about.js
@@ -108,7 +108,7 @@ var Credits = React.createClass({
     render() {
         return <div className='center-block lead row'>
             <p>
-                Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.
+                Map tiles by <a href="http://stamen.com">Stamen Design</a> and <a href="https://stadiamaps.com">Stadia Maps</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.
             </p>
         </div>;
     }

--- a/js/app.js
+++ b/js/app.js
@@ -303,7 +303,7 @@ var Resources = React.createClass({
 
         // watercolor, toner, terrain
         //   var layer = new L.StamenTileLayer('terrain');
-        var layer = L.tileLayer('https://stamen-tiles.a.ssl.fastly.net/terrain/{z}/{x}/{y}.jpg', {
+        var layer = L.tileLayer('https://tiles.stadiamaps.com/tiles/stamen_terrain/{z}/{x}/{y}{r}.jpg', {
             opacity: 0.8
         });
         this.map.addLayer(layer);


### PR DESCRIPTION
Convert from Stamen to Stadia Maps for map layer hosting - Stamen is no longer hosting these tiles directly.