### PR TITLE
pin pdal to 2.7 to avoid filters bug

### DIFF
--- a/.github/workflows/boundaries.yml
+++ b/.github/workflows/boundaries.yml
@@ -31,7 +31,7 @@ jobs:
       shell: bash -l {0}
       run: |
           conda config --add channels conda-forge
-          conda install -c conda-forge pdal pystac Shapely pyproj Fiona nodejs -y
+          conda install -c conda-forge pdal=2.7 pystac Shapely pyproj Fiona nodejs -y
           cd action; pip install requests boto3 awscli; pip install -e .
           npm install -g topojson-server
     - name: Gather boundaries

--- a/action/usgs_boundary/proqueue.py
+++ b/action/usgs_boundary/proqueue.py
@@ -55,7 +55,7 @@ class Task(object):
 
         try:
             self.poly = loads(self.wkt)
-            if self.poly.type == 'Polygon':
+            if self.poly.geom_type == 'Polygon':
                 self.poly = MultiPolygon([self.poly])
             self.poly = transform(transformation.transform, self.poly)
         except Exception as E:


### PR DESCRIPTION
- Pin PDAL to 2.7 to address #74 
- Use `geom_type` for shapely polygon object, `type` is deprecated
