### PR TITLE
remove pointcloud extension in catalog and other small cleanup

### DIFF
--- a/action/usgs_boundary/info.py
+++ b/action/usgs_boundary/info.py
@@ -72,7 +72,7 @@ def info(args):
     catalog = pystac.Catalog('3dep',
                          'A catalog of USGS 3DEP Lidar hosted on AWS s3.',
                          href=f'{args.stac_base_url}catalog.json',
-                         stac_extensions=['POINTCLOUD'])
+                         stac_extensions=[])
 
     base = Path(args.stac_directory)
     base.mkdir(exist_ok=True, parents=True)

--- a/action/usgs_boundary/proqueue.py
+++ b/action/usgs_boundary/proqueue.py
@@ -69,7 +69,7 @@ class Task(object):
             self.info()
             self.geometry()
 
-        except (AttributeError, KeyError, json.decoder.JSONDecodeError,shapely.errors.WKTReadingError):
+        except (AttributeError, KeyError, json.decoder.JSONDecodeError, shapely.errors.ShapelyError) as e:
             pass
 
     def count (self):
@@ -120,5 +120,4 @@ class Process(object):
     def do(self, count = multiprocessing.cpu_count()):
         pool = multiprocessing.Pool(processes=count)
         self.results = (pool.map(run, self.tasks))
-#        import pdb;pdb.set_trace()
 

--- a/action/usgs_boundary/proqueue.py
+++ b/action/usgs_boundary/proqueue.py
@@ -69,7 +69,7 @@ class Task(object):
             self.info()
             self.geometry()
 
-        except (AttributeError, KeyError, json.decoder.JSONDecodeError, shapely.errors.ShapelyError) as e:
+        except (AttributeError, KeyError, json.decoder.JSONDecodeError, shapely.errors.ShapelyError):
             pass
 
     def count (self):


### PR DESCRIPTION
- removed `POINTCLOUD` string from extensions in Catalog, which made validation in the Catalog fail
- changed out WKtReadingError for ShapelyError per the warning message from Shapely
- removed commented out pdb.set_trace()